### PR TITLE
Fix schedule listing bug

### DIFF
--- a/backend/app/services/horario_service.py
+++ b/backend/app/services/horario_service.py
@@ -92,7 +92,7 @@ class HorarioService:
                 medico_id=medico_id,
                 dia_semana=dia_semana,
                 ativo=True
-            ).order_by(AgendaMedico.horario_inicio).all()
+            ).order_by(AgendaMedico.hora_inicio).all()
             
             if not horarios:
                 return []


### PR DESCRIPTION
## Summary
- fix `horario_service` query to use `hora_inicio`

## Testing
- `python3 -m py_compile backend/app/**/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685890a44fe4832a91c1f10dee8deba7